### PR TITLE
Do not duplicate stock moves on backorders

### DIFF
--- a/connector_bots/stock.py
+++ b/connector_bots/stock.py
@@ -415,12 +415,14 @@ class StockPickingAdapter(BotsCRUDAdapter):
 
         # Split picking depending on order policy
         if not picking_complete:
-            picking_policy = picking.move_type or picking.sale_id and picking.sale_id.picking_policy or 'direct'
+            sale_policy = picking.sale_id and picking.sale_id.picking_policy or 'direct'
+            picking_policy = picking.move_type or sale_policy
             if picking_policy != 'direct':
                 raise InvalidDataError(_('Unable to export picking %s. Picking policy does not allow it to be split and is not fully complete or some products are not mapped for export.') % (picking_id,))
             # Split the picking
             new_picking_id = picking_obj.copy(self.session.cr, self.session.uid, picking.openerp_id.id,
                                               {
+                                                  'move_type': sale_policy,
                                                   'move_lines': [],
                                               },
                                               context=ctx)


### PR DESCRIPTION
When creating a backorder, the picking gets a duplicate of the stock moves, essentially adding another sale order's worth to be send to the customer...

Also, create the new picking with the sale order's picking policy to enable the "send what we have, then all the rest at once" scenario.
