### PR TITLE
[IMP] Do not drop entries when done with them

### DIFF
--- a/connector_bots/connector.py
+++ b/connector_bots/connector.py
@@ -44,6 +44,11 @@ class BotsBinding(orm.AbstractModel):
             required=True,
             ondelete='restrict'),
         'bots_id': fields.char('ID on Bots'),
+        'active': fields.boolean('Active'),
+    }
+
+    _defaults = {
+        'active': True,
     }
 
 def add_checkpoint(session, model_name, record_id, backend_id):

--- a/connector_bots/stock_view.xml
+++ b/connector_bots/stock_view.xml
@@ -53,6 +53,7 @@
                         <group>
                             <group>
                                 <field name="bots_id"/>
+                                <field name="active"/>
                                 <field name="warehouse_id" readonly="1"/>
                                 <field name="openerp_id" context="{'wms_bots': True}"/>
                                 <field name="bots_override"/>
@@ -127,6 +128,7 @@
                         <group>
                             <group>
                                 <field name="bots_id"/>
+                                <field name="active"/>
                                 <field name="warehouse_id" readonly="1"/>
                                 <field name="openerp_id" context="{'wms_bots': True}"/>
                                 <field name="bots_override"/>

--- a/connector_bots/unit/backend_adapter.py
+++ b/connector_bots/unit/backend_adapter.py
@@ -67,7 +67,6 @@ def file_to_process(session, filename_id, new_cr=True):
         # noone else will try to do so again. It can be archived now but should
         # that fail, nothing happens, really, as anyone can do the move later
         os.rename(file.full_path, file.arch_path)
-        file_obj.unlink(cr, SUPERUSER_ID, filename_id)
     except:
         cr.rollback()
         raise
@@ -173,7 +172,6 @@ class BotsCRUDAdapter(CRUDAdapter):
                     if f['processed']:
                         try:
                             os.rename(file[1], f['arch_path'])
-                            file_obj.unlink(_cr, SUPERUSER_ID, file_id)
                         except IOError, e:
                             _logger.exception('Error trying to move file %s -> %s', file[1], f['arch_path'])
                         continue

--- a/connector_bots/unit/binder.py
+++ b/connector_bots/unit/binder.py
@@ -52,10 +52,11 @@ class BotsModelBinder(BotsBinder):
                  or None if the external_id is not mapped
         :rtype: int
         """
-        binding_ids = self.session.search(
-                self.model._name,
-                [('bots_id', '=', str(external_id)),
-                 ('backend_id', '=', self.backend_record.id)])
+        binding_ids = self.session.search( self.model._name, [
+            ('bots_id', '=', str(external_id)),
+            ('backend_id', '=', self.backend_record.id),
+            ('active', '=', True),
+        ])
         if not binding_ids:
             return None
         assert len(binding_ids) == 1, "Several records found: %s" % binding_ids
@@ -79,8 +80,9 @@ class BotsModelBinder(BotsBinder):
         """
         if wrap:
             erp_id = self.session.search(self.model._name, [
-                ['openerp_id', '=', record_id],
-                ['bots_id', '=', self.backend_record.id]
+                ('openerp_id', '=', record_id),
+                ('bots_id', '=', self.backend_record.id),
+                ('active', '=', True),
             ])
             if erp_id:
                 record_id = erp_id[0]


### PR DESCRIPTION
To improve traceability, we should not be removing bots_\* lines as queue.job tasks usually reference them.
